### PR TITLE
Update jspsych-webgazer-calibration.js

### DIFF
--- a/resources/jspsych-webgazer-calibration.js
+++ b/resources/jspsych-webgazer-calibration.js
@@ -368,7 +368,7 @@ button {
                             title: trial_info.calibration_failed_text,
                             confirm: trial_info.restart_calibration_button_label
                         }).then((result) => {
-                            plugin_ref.restartCalibration(false);
+                            plugin_ref.restartCalibration(true);
                             calibration_tries++;
                         });
                     }


### PR DESCRIPTION
Show instructions before re-calibration (re-calibration can occur at any point in the experiment, participants may forget what they need to do by that point).